### PR TITLE
remove Python2 crumbs

### DIFF
--- a/easydev/platform.py
+++ b/easydev/platform.py
@@ -13,7 +13,6 @@
 #  Documentation: http://easydev-python.readthedocs.io
 #
 ##############################################################################
-from __future__ import absolute_import  # avoids conflict with standard module
 
 import os
 import sys

--- a/easydev/progressbar.py
+++ b/easydev/progressbar.py
@@ -14,7 +14,6 @@
 #
 ##############################################################################
 """A progress bar copied and adapted from pyMC code (dec 2014)"""
-from __future__ import print_function
 
 import sys
 import time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ pytest-timeout = "^2.2.0"
 pytest-runner = "^6.0.1"
 coveralls = "^3.3.1"
 flaky = "^3.7.0"
-mock = "^5.1.0"
 
 
 [tool.poetry.group.doc.dependencies]

--- a/test/test_appdirs.py
+++ b/test/test_appdirs.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 
 def test_app():

--- a/test/test_browse.py
+++ b/test/test_browse.py
@@ -1,9 +1,6 @@
 from easydev import browser
 
-try:
-    from unittest.mock import patch
-except:
-    from mock import patch
+from unittest.mock import patch
 
 
 def test_browse(mocker):

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1,6 +1,6 @@
 import os.path
 
-# from mock import patch
+# from unittest.mock import patch
 import subprocess
 
 from easydev.misc import cmd_exists, get_home, in_ipynb


### PR DESCRIPTION
mock is now part of the Python standard library, available as unittest.mock in Python 3.3 onwards.

https://github.com/testing-cabal/mock